### PR TITLE
Change this.fuelSlot to this.getFuelSlot() in Plane#serialize to fix NPE in ShipsFileLoader#save

### DIFF
--- a/src/main/java/org/ships/vessel/common/types/typical/plane/Plane.java
+++ b/src/main/java/org/ships/vessel/common/types/typical/plane/Plane.java
@@ -90,7 +90,7 @@ public class Plane extends AbstractShipsVessel implements AirType, VesselRequire
     public Map<ConfigurationNode.KnownParser<?, ?>, Object> serialize(ConfigurationStream file) {
         Map<ConfigurationNode.KnownParser<?, ?>, Object> map = new HashMap<>();
         map.put(this.configFuelConsumption, this.getFuelConsumption());
-        map.put(this.configFuelSlot, this.fuelSlot);
+        map.put(this.configFuelSlot, this.getFuelSlot());
         map.put(this.configFuelTypes, this.getFuelTypes());
         return map;
     }


### PR DESCRIPTION
When creating a Plane vessel with Ships beta10, I noticed that a NullPointerException would consistently be thrown ([https://pastebin.com/raw/bp6jeJsy](https://pastebin.com/raw/bp6jeJsy)) when placing the license sign for the vessel, which led to no Plane vessel ever being able to be created. I figured that the reason for this was that Plane's `fuelSlot` field was never checked for being null before being put in the `serialize` map as a value that `ShipsFileLoader#save` would ultimately pass to `StringToEnumParser#unparse`, leading to `value.toString()` throwing the NPE. This PR just changes the fuelSlot serialization code to handle those null values so the vessels can be used in the plugin.

While I was diagnosing this, I also saw that Airship has a similar problem in its `serialize` method leading to a ClassCastException being thrown [https://pastebin.com/raw/M3zbMQe0](https://pastebin.com/raw/M3zbMQe0), since the line `map.put(this.configFuelSlot, this.getFuelSlot().equals(FuelSlot.TOP))` looks like it needs to be `map.put(this.configFuelSlot, this.getFuelSlot())`. That bug isn't as big of an issue since it won't stop the vessel from being created, but it's still worth pointing out.